### PR TITLE
Instant navigation via View Transitions + photography overhaul

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,11 +3,9 @@
     <LoadingBar />
     <Navbar />
     <Terminal v-if="terminalState.active" />
-    <router-view v-else v-slot="{ Component, route }">
-      <transition name="fade" mode="out-in">
-        <component :is="Component" :key="route.path" />
-      </transition>
-    </router-view>
+    <!-- Page changes animate via the View Transitions API (lib/viewTransitions.js)
+         instead of an out-in component transition, so the swap is instant. -->
+    <router-view v-else />
     <footer class="site-footer">
       <span>© {{ year }} jaime ferrando huertas</span>
       <span>
@@ -19,8 +17,6 @@
       </span>
     </footer>
   </div>
-
-  <SpeedInsights />
 </template>
 
 <script>

--- a/src/assets/generate_imageDictionary.js
+++ b/src/assets/generate_imageDictionary.js
@@ -1,121 +1,130 @@
+// Build-time photo pipeline.
+//
+// Walks src/assets/img/photography/original/ and produces, per image:
+//   thumbnails/  — 800px wide, q75 (gallery grid)
+//   medium_res/  — max 2048px wide, q75 (lightbox)
+// plus two manifests next to this file:
+//   imageDictionary.json — { section: [originalPath, ...] } (unchanged format)
+//   imageMeta.json       — { originalPath: { w, h } } for aspect-ratio
+//                          placeholders (no layout shift while lazy-loading)
+//
+// Generation is incremental: outputs newer than their source are skipped, so
+// local runs and CI builds only pay for new or changed photos.
+
 import fs from 'fs';
 import path from 'path';
 import sharp from 'sharp';
-import {
-	fileURLToPath
-} from 'url';
-import {
-	dirname
-} from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
 
-const __filename = fileURLToPath(
-	import.meta.url);
+const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const imageExtensions = new Set(['.png', '.jpg', '.jpeg', '.gif', '.bmp',
-	'.svg'
-]);
 
-const basePath = __dirname + '/img/photography/';
-const original_base_path = basePath + 'original/';
-const medium_res_base_path = basePath + 'medium_res/';
-const thumbnailsPath = basePath + 'thumbnails';
+const imageExtensions = new Set(['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.svg']);
 
-const image_dict_path = "/assets/img/photography/original/";
+const basePath = path.join(__dirname, 'img/photography');
+const originalPath = path.join(basePath, 'original');
+const mediumPath = path.join(basePath, 'medium_res');
+const thumbnailsPath = path.join(basePath, 'thumbnails');
 
-// Ensure the thumbnails directory exists
-if (!fs.existsSync(thumbnailsPath)) {
-	fs.mkdirSync(thumbnailsPath, {
-		recursive: true
-	});
-}
+const PUBLIC_PREFIX = '/assets/img/photography/original/';
 
-// Ensure the medium_res directory exists
-if (!fs.existsSync(medium_res_base_path)) {
-	fs.mkdirSync(medium_res_base_path, {
-		recursive: true
-	});
-}
+const THUMB_WIDTH = 800;
+const MEDIUM_WIDTH = 2048;
+const JPEG_QUALITY = 75;
+const CONCURRENCY = 4;
 
-const generateImageDictionary = (basePath) => {
-	const imageDictionary = {
-		".": []
-	};
+const isUpToDate = (src, out) =>
+	fs.existsSync(out) && fs.statSync(out).mtimeMs >= fs.statSync(src).mtimeMs;
 
-	const walkSync = (dir, relativePath) => {
-		const files = fs.readdirSync(dir);
-
-		files.forEach((file) => {
-			const filePath = path.join(dir, file);
-			const fileStat = fs.statSync(filePath);
-
-			if (fileStat.isDirectory()) {
-				const subDirPath = path.join(thumbnailsPath,
-					relativePath, file);
-				if (!fs.existsSync(subDirPath)) {
-					fs.mkdirSync(subDirPath, {
-						recursive: true
-					});
-				}
-				const subDirPathMediumRes = path.join(
-					medium_res_base_path, relativePath, file
-				);
-				if (!fs.existsSync(subDirPathMediumRes)) {
-					fs.mkdirSync(subDirPathMediumRes, {
-						recursive: true
-					});
-				}
-				walkSync(filePath, path.join(relativePath,
-					file)); // Recursive call for subdirectories
-			} else if (imageExtensions.has(path.extname(file)
-					.toLowerCase())) {
-				const key = relativePath === '' ? '.' :
-					relativePath;
-				if (!imageDictionary[key]) {
-					imageDictionary[key] = [];
-				}
-				const relativeFilePath = key === '.' ? file :
-					path.join(key, file);
-				const thumbnailFilePath = path.join(
-					thumbnailsPath, relativeFilePath);
-
-
-				// Generate thumbnail
-				sharp(filePath)
-					.resize({
-						width: 800
-					})
-					.toFormat(
-						'jpeg'
-					) // Convert to jpeg for size efficiency
-					.toFile(thumbnailFilePath, (err, info) => {
-						if (err) throw err;
-					});
-
-
-				// Convert to jpeg for size efficency, save and store in dictionary.
-				sharp(filePath)
-					.jpeg({
-						quality: 50
-					})
-					.toFile(medium_res_base_path +
-						relativeFilePath),
-					(err, info) => {
-						if (err) throw err;
-					}
-				imageDictionary[key].push(image_dict_path +
-					relativeFilePath);
-			}
-		});
-	};
-
-	walkSync(original_base_path, '');
-
-	return imageDictionary;
+// Collect every image under original/, keyed by section (subdirectory).
+const collectImages = (dir, relativePath = '') => {
+	const entries = [];
+	for (const file of fs.readdirSync(dir).sort()) {
+		const filePath = path.join(dir, file);
+		const rel = relativePath === '' ? file : path.posix.join(relativePath, file);
+		if (fs.statSync(filePath).isDirectory()) {
+			entries.push(...collectImages(filePath, rel));
+		} else if (imageExtensions.has(path.extname(file).toLowerCase())) {
+			entries.push({ filePath, rel, section: relativePath === '' ? '.' : relativePath });
+		}
+	}
+	return entries;
 };
 
-// Get current image dictionary
-const imageDictionary = generateImageDictionary(basePath);
+const processImage = async ({ filePath, rel }, meta) => {
+	const thumbOut = path.join(thumbnailsPath, rel);
+	const mediumOut = path.join(mediumPath, rel);
+	fs.mkdirSync(path.dirname(thumbOut), { recursive: true });
+	fs.mkdirSync(path.dirname(mediumOut), { recursive: true });
 
-// Write the dictionary to a JSON file
-fs.writeFileSync(path.join(__dirname, 'imageDictionary.json'), JSON.stringify(
-	imageDictionary, null, 2), 'utf-8');
+	// Dimensions as displayed (swap when EXIF orientation rotates the image).
+	const md = await sharp(filePath).metadata();
+	let { width, height } = md;
+	if (md.orientation && md.orientation >= 5) [width, height] = [height, width];
+	meta[PUBLIC_PREFIX + rel] = { w: width, h: height };
+
+	if (!isUpToDate(filePath, thumbOut)) {
+		await sharp(filePath)
+			.rotate() // bake EXIF orientation
+			.resize({ width: THUMB_WIDTH, withoutEnlargement: true })
+			.jpeg({ quality: JPEG_QUALITY, mozjpeg: true })
+			.toFile(thumbOut);
+	}
+
+	if (!isUpToDate(filePath, mediumOut)) {
+		await sharp(filePath)
+			.rotate()
+			.resize({ width: MEDIUM_WIDTH, withoutEnlargement: true })
+			.jpeg({ quality: JPEG_QUALITY, mozjpeg: true })
+			.toFile(mediumOut);
+	}
+};
+
+const run = async () => {
+	const images = collectImages(originalPath);
+
+	const dictionary = { '.': [] };
+	for (const { rel, section } of images) {
+		if (!dictionary[section]) dictionary[section] = [];
+		dictionary[section].push(PUBLIC_PREFIX + rel);
+	}
+
+	const meta = {};
+	const queue = [...images];
+	let failures = 0;
+	await Promise.all(
+		Array.from({ length: CONCURRENCY }, async () => {
+			while (queue.length) {
+				const job = queue.pop();
+				try {
+					await processImage(job, meta);
+				} catch (err) {
+					failures += 1;
+					console.error(`[images] failed on ${job.rel}: ${err.message}`);
+				}
+			}
+		})
+	);
+
+	// Stable key order so the committed manifests diff cleanly.
+	const sortedMeta = Object.fromEntries(
+		Object.keys(meta).sort().map((k) => [k, meta[k]])
+	);
+
+	fs.writeFileSync(
+		path.join(__dirname, 'imageDictionary.json'),
+		JSON.stringify(dictionary, null, 2),
+		'utf-8'
+	);
+	fs.writeFileSync(
+		path.join(__dirname, 'imageMeta.json'),
+		JSON.stringify(sortedMeta, null, 2),
+		'utf-8'
+	);
+
+	console.log(`[images] ${images.length} photos, ${failures} failures`);
+	if (failures > 0) process.exitCode = 1;
+};
+
+run();

--- a/src/assets/imageMeta.json
+++ b/src/assets/imageMeta.json
@@ -1,0 +1,490 @@
+{
+  "/assets/img/photography/original/family/30_06_2023_0031.jpg": {
+    "w": 2999,
+    "h": 4405
+  },
+  "/assets/img/photography/original/family/30_06_2023_0037.jpg": {
+    "w": 4120,
+    "h": 2760
+  },
+  "/assets/img/photography/original/family/30_06_2023_0085.jpg": {
+    "w": 4471,
+    "h": 2999
+  },
+  "/assets/img/photography/original/family/30_06_2023_0144.jpg": {
+    "w": 4369,
+    "h": 2946
+  },
+  "/assets/img/photography/original/family/30_06_2023_0148.jpg": {
+    "w": 4471,
+    "h": 2999
+  },
+  "/assets/img/photography/original/family/30_06_2023_0150.jpg": {
+    "w": 4471,
+    "h": 2999
+  },
+  "/assets/img/photography/original/family/30_06_2023_0158.jpg": {
+    "w": 4471,
+    "h": 2999
+  },
+  "/assets/img/photography/original/family/30_06_2023_0213.jpg": {
+    "w": 3848,
+    "h": 2655
+  },
+  "/assets/img/photography/original/family/DSC01659.jpg": {
+    "w": 5761,
+    "h": 3851
+  },
+  "/assets/img/photography/original/family/DSC01776-positive.jpg": {
+    "w": 4000,
+    "h": 6000
+  },
+  "/assets/img/photography/original/family/DSCF4495.jpg": {
+    "w": 6240,
+    "h": 4160
+  },
+  "/assets/img/photography/original/family/DSCF6245.jpg": {
+    "w": 4059,
+    "h": 6088
+  },
+  "/assets/img/photography/original/family/DSCF7050.jpg": {
+    "w": 6018,
+    "h": 4012
+  },
+  "/assets/img/photography/original/family/DSC_0372.jpg": {
+    "w": 4000,
+    "h": 6000
+  },
+  "/assets/img/photography/original/family/Jaime Fernando Huertas038.jpg": {
+    "w": 3555,
+    "h": 2397
+  },
+  "/assets/img/photography/original/family/Jaime Fernando Huertas042.jpg": {
+    "w": 3555,
+    "h": 2397
+  },
+  "/assets/img/photography/original/family/Jaime Fernando Huertas056.jpg": {
+    "w": 3555,
+    "h": 2397
+  },
+  "/assets/img/photography/original/family/Jaime Fernando Huertas069.jpg": {
+    "w": 3555,
+    "h": 2397
+  },
+  "/assets/img/photography/original/family/Jaime Fernando Huertas071.jpg": {
+    "w": 3555,
+    "h": 2397
+  },
+  "/assets/img/photography/original/family/Jaime Ferrando Huertas-20.jpg": {
+    "w": 2999,
+    "h": 4471
+  },
+  "/assets/img/photography/original/family/Paula Ferrando -115.jpg": {
+    "w": 2999,
+    "h": 4464
+  },
+  "/assets/img/photography/original/family/Paula Ferrando -212.jpg": {
+    "w": 4365,
+    "h": 2932
+  },
+  "/assets/img/photography/original/family/Paula Ferrando -22.jpg": {
+    "w": 4389,
+    "h": 2949
+  },
+  "/assets/img/photography/original/family/Paula Ferrando -226.jpg": {
+    "w": 4464,
+    "h": 2999
+  },
+  "/assets/img/photography/original/family/Paula Ferrando -3.jpg": {
+    "w": 2431,
+    "h": 2155
+  },
+  "/assets/img/photography/original/family/Paula Ferrando -82.jpg": {
+    "w": 3951,
+    "h": 2805
+  },
+  "/assets/img/photography/original/faroe/R1-09434-010A.jpg": {
+    "w": 3670,
+    "h": 2501
+  },
+  "/assets/img/photography/original/faroe/R1-09434-014A.jpg": {
+    "w": 3708,
+    "h": 2472
+  },
+  "/assets/img/photography/original/faroe/R1-09434-019A.jpg": {
+    "w": 3708,
+    "h": 2527
+  },
+  "/assets/img/photography/original/faroe/faroe_0146.jpg": {
+    "w": 2675,
+    "h": 4099
+  },
+  "/assets/img/photography/original/faroe/faroe_0149.jpg": {
+    "w": 2665,
+    "h": 1712
+  },
+  "/assets/img/photography/original/faroe/faroe_0159.jpg": {
+    "w": 4471,
+    "h": 2999
+  },
+  "/assets/img/photography/original/faroe/faroe_0161.jpg": {
+    "w": 2999,
+    "h": 4471
+  },
+  "/assets/img/photography/original/faroe/faroe_0162.jpg": {
+    "w": 4125,
+    "h": 2703
+  },
+  "/assets/img/photography/original/faroe/faroe_0163.jpg": {
+    "w": 4119,
+    "h": 2737
+  },
+  "/assets/img/photography/original/faroe/faroe_0233.jpg": {
+    "w": 4471,
+    "h": 2999
+  },
+  "/assets/img/photography/original/faroe/faroe_0234.jpg": {
+    "w": 2759,
+    "h": 4142
+  },
+  "/assets/img/photography/original/faroe/faroe_0235.jpg": {
+    "w": 4113,
+    "h": 2679
+  },
+  "/assets/img/photography/original/faroe/faroe_0245.jpg": {
+    "w": 2723,
+    "h": 4071
+  },
+  "/assets/img/photography/original/faroe/faroe_0254.jpg": {
+    "w": 4471,
+    "h": 2999
+  },
+  "/assets/img/photography/original/faroe/faroe_0301.jpg": {
+    "w": 4471,
+    "h": 2999
+  },
+  "/assets/img/photography/original/life/221206JF_0066-5.jpg": {
+    "w": 3571,
+    "h": 2253
+  },
+  "/assets/img/photography/original/life/30_06_2023_0037.jpg": {
+    "w": 4120,
+    "h": 2760
+  },
+  "/assets/img/photography/original/life/30_06_2023_0098.jpg": {
+    "w": 3202,
+    "h": 2101
+  },
+  "/assets/img/photography/original/life/30_06_2023_0111.jpg": {
+    "w": 4127,
+    "h": 2756
+  },
+  "/assets/img/photography/original/life/30_06_2023_0128.jpg": {
+    "w": 3797,
+    "h": 2543
+  },
+  "/assets/img/photography/original/life/DSC00107.jpg": {
+    "w": 6000,
+    "h": 4000
+  },
+  "/assets/img/photography/original/life/DSC00258.jpg": {
+    "w": 4908,
+    "h": 3272
+  },
+  "/assets/img/photography/original/life/DSC00404.jpg": {
+    "w": 4000,
+    "h": 6000
+  },
+  "/assets/img/photography/original/life/DSC01664.jpg": {
+    "w": 5790,
+    "h": 3832
+  },
+  "/assets/img/photography/original/life/Paula Ferrando -3.jpg": {
+    "w": 2431,
+    "h": 2155
+  },
+  "/assets/img/photography/original/life/Paula Ferrando -37.jpg": {
+    "w": 4389,
+    "h": 2949
+  },
+  "/assets/img/photography/original/life/Paula Ferrando -70-photoshop.jpg": {
+    "w": 4389,
+    "h": 2949
+  },
+  "/assets/img/photography/original/milu/09_01_2024_0226.jpg": {
+    "w": 2999,
+    "h": 4405
+  },
+  "/assets/img/photography/original/milu/221206JF_0067-22.jpg": {
+    "w": 3900,
+    "h": 2687
+  },
+  "/assets/img/photography/original/milu/30_06_2023_0064.jpg": {
+    "w": 4405,
+    "h": 2999
+  },
+  "/assets/img/photography/original/milu/30_06_2023_0114.jpg": {
+    "w": 4405,
+    "h": 2999
+  },
+  "/assets/img/photography/original/milu/30_06_2023_0141.jpg": {
+    "w": 4095,
+    "h": 2704
+  },
+  "/assets/img/photography/original/milu/DSC01765.jpg": {
+    "w": 3793,
+    "h": 5701
+  },
+  "/assets/img/photography/original/nature/09_01_2024_0220.jpg": {
+    "w": 3930,
+    "h": 2585
+  },
+  "/assets/img/photography/original/nature/09_01_2024_0274.jpg": {
+    "w": 3207,
+    "h": 2148
+  },
+  "/assets/img/photography/original/nature/39225246575_678b236c4e_o.jpg": {
+    "w": 4752,
+    "h": 3168
+  },
+  "/assets/img/photography/original/nature/DSCF5229-Edit.jpg": {
+    "w": 5947,
+    "h": 3345
+  },
+  "/assets/img/photography/original/nature/DSCF5373.jpg": {
+    "w": 6240,
+    "h": 2613
+  },
+  "/assets/img/photography/original/nature/DSCF7157.jpg": {
+    "w": 5321,
+    "h": 2786
+  },
+  "/assets/img/photography/original/nature/DSC_0192 - Copy (3).jpg": {
+    "w": 6000,
+    "h": 4000
+  },
+  "/assets/img/photography/original/nature/DSC_0328.jpg": {
+    "w": 6000,
+    "h": 4000
+  },
+  "/assets/img/photography/original/nature/DSC_0351.jpg": {
+    "w": 6000,
+    "h": 4000
+  },
+  "/assets/img/photography/original/nature/DSC_0429.jpg": {
+    "w": 6000,
+    "h": 4000
+  },
+  "/assets/img/photography/original/nature/DSC_0621.jpg": {
+    "w": 6000,
+    "h": 4000
+  },
+  "/assets/img/photography/original/nature/IMG_0572.jpg": {
+    "w": 4752,
+    "h": 3168
+  },
+  "/assets/img/photography/original/nature/IMG_1036.jpg": {
+    "w": 4391,
+    "h": 2927
+  },
+  "/assets/img/photography/original/nature/R1-09434-010A.jpg": {
+    "w": 3670,
+    "h": 2501
+  },
+  "/assets/img/photography/original/nature/R1-09434-014A.jpg": {
+    "w": 3708,
+    "h": 2472
+  },
+  "/assets/img/photography/original/nature/R1-09434-019A.jpg": {
+    "w": 3708,
+    "h": 2527
+  },
+  "/assets/img/photography/original/nature/faroe_0146.jpg": {
+    "w": 2675,
+    "h": 4099
+  },
+  "/assets/img/photography/original/nature/faroe_0149.jpg": {
+    "w": 2665,
+    "h": 1712
+  },
+  "/assets/img/photography/original/nature/faroe_0159.jpg": {
+    "w": 4471,
+    "h": 2999
+  },
+  "/assets/img/photography/original/nature/faroe_0161.jpg": {
+    "w": 2999,
+    "h": 4471
+  },
+  "/assets/img/photography/original/nature/faroe_0162.jpg": {
+    "w": 4125,
+    "h": 2703
+  },
+  "/assets/img/photography/original/nature/faroe_0163.jpg": {
+    "w": 4119,
+    "h": 2737
+  },
+  "/assets/img/photography/original/nature/faroe_0233.jpg": {
+    "w": 4471,
+    "h": 2999
+  },
+  "/assets/img/photography/original/nature/faroe_0234.jpg": {
+    "w": 2759,
+    "h": 4142
+  },
+  "/assets/img/photography/original/nature/faroe_0235.jpg": {
+    "w": 4113,
+    "h": 2679
+  },
+  "/assets/img/photography/original/nature/faroe_0245.jpg": {
+    "w": 2723,
+    "h": 4071
+  },
+  "/assets/img/photography/original/nature/faroe_0254.jpg": {
+    "w": 4471,
+    "h": 2999
+  },
+  "/assets/img/photography/original/nature/faroe_0301.jpg": {
+    "w": 4471,
+    "h": 2999
+  },
+  "/assets/img/photography/original/portraits/09_01_2024_0141.jpg": {
+    "w": 2720,
+    "h": 4121
+  },
+  "/assets/img/photography/original/portraits/09_01_2024_0212.jpg": {
+    "w": 4048,
+    "h": 2707
+  },
+  "/assets/img/photography/original/portraits/30_06_2023_0077.jpg": {
+    "w": 2999,
+    "h": 4471
+  },
+  "/assets/img/photography/original/portraits/30_06_2023_0208.jpg": {
+    "w": 4405,
+    "h": 2999
+  },
+  "/assets/img/photography/original/portraits/30_06_2023_0213.jpg": {
+    "w": 3848,
+    "h": 2655
+  },
+  "/assets/img/photography/original/portraits/R1-09434-002A.jpg": {
+    "w": 2457,
+    "h": 3564
+  },
+  "/assets/img/photography/original/street/09_01_2024_0163.jpg": {
+    "w": 4113,
+    "h": 2644
+  },
+  "/assets/img/photography/original/street/09_01_2024_0270.jpg": {
+    "w": 3575,
+    "h": 2397
+  },
+  "/assets/img/photography/original/street/09_01_2024_0299.jpg": {
+    "w": 4471,
+    "h": 2999
+  },
+  "/assets/img/photography/original/street/09_01_2024_0305-Edit.jpg": {
+    "w": 2999,
+    "h": 4471
+  },
+  "/assets/img/photography/original/street/221206JF_0066-36.jpg": {
+    "w": 3900,
+    "h": 2663
+  },
+  "/assets/img/photography/original/street/230103JF_0660-26.jpg": {
+    "w": 3900,
+    "h": 2689
+  },
+  "/assets/img/photography/original/street/30_06_2023_0028.jpg": {
+    "w": 2999,
+    "h": 4405
+  },
+  "/assets/img/photography/original/street/30_06_2023_0042-Enhanced.jpg": {
+    "w": 7391,
+    "h": 3461
+  },
+  "/assets/img/photography/original/street/31_05_2023_0037-2.jpg": {
+    "w": 2999,
+    "h": 4405
+  },
+  "/assets/img/photography/original/street/31_05_2023_0052-2.jpg": {
+    "w": 3883,
+    "h": 2615
+  },
+  "/assets/img/photography/original/street/DSC00092-Enhanced.jpg": {
+    "w": 11403,
+    "h": 7602
+  },
+  "/assets/img/photography/original/street/DSC00107.jpg": {
+    "w": 6000,
+    "h": 4000
+  },
+  "/assets/img/photography/original/street/DSC00418.jpg": {
+    "w": 4000,
+    "h": 6000
+  },
+  "/assets/img/photography/original/street/DSCF0184_1.jpg": {
+    "w": 4012,
+    "h": 5016
+  },
+  "/assets/img/photography/original/street/DSCF3971-2.jpg": {
+    "w": 5956,
+    "h": 3971
+  },
+  "/assets/img/photography/original/street/DSCF3979-3.jpg": {
+    "w": 3437,
+    "h": 5155
+  },
+  "/assets/img/photography/original/street/DSCF4030-3.jpg": {
+    "w": 3581,
+    "h": 5371
+  },
+  "/assets/img/photography/original/street/DSCF4044-2.jpg": {
+    "w": 5014,
+    "h": 3343
+  },
+  "/assets/img/photography/original/street/DSCF6481_1.jpg": {
+    "w": 5861,
+    "h": 3907
+  },
+  "/assets/img/photography/original/street/DSCF6784.jpg": {
+    "w": 6046,
+    "h": 4160
+  },
+  "/assets/img/photography/original/street/DSCF7332.jpg": {
+    "w": 5513,
+    "h": 3675
+  },
+  "/assets/img/photography/original/street/Jaime Ferrando Huertas-3.jpg": {
+    "w": 4471,
+    "h": 2999
+  },
+  "/assets/img/photography/original/street/Paula Ferrando -102.jpg": {
+    "w": 3732,
+    "h": 2531
+  },
+  "/assets/img/photography/original/street/Paula Ferrando -156.jpg": {
+    "w": 3788,
+    "h": 2638
+  },
+  "/assets/img/photography/original/street/Paula Ferrando -202.jpg": {
+    "w": 4464,
+    "h": 2999
+  },
+  "/assets/img/photography/original/street/Paula Ferrando -209.jpg": {
+    "w": 2693,
+    "h": 4083
+  },
+  "/assets/img/photography/original/street/Paula Ferrando -97.jpg": {
+    "w": 4389,
+    "h": 2949
+  },
+  "/assets/img/photography/original/street/faroe_0101.jpg": {
+    "w": 2675,
+    "h": 4099
+  },
+  "/assets/img/photography/original/street/valencia-horta.jpg": {
+    "w": 4402,
+    "h": 2957
+  }
+}

--- a/src/components/LoadingBar.vue
+++ b/src/components/LoadingBar.vue
@@ -3,24 +3,39 @@
 </template>
 
 <script>
+// Route chunks are prefetched on idle, so navigation is normally instant.
+// The bar only appears when a navigation genuinely stalls (cold chunk on a
+// slow connection) — showing it on every click makes fast pages feel slow.
+const SLOW_NAVIGATION_MS = 250;
+
 export default {
   name: 'LoadingBar',
   data() {
     return {
       isLoading: false,
+      showTimer: null,
     };
   },
   mounted() {
-    this.$router.beforeEach((to, from, next) => {
-      this.isLoading = true;
-      next();
-    });
-
-    this.$router.afterEach(() => {
-      setTimeout(() => {
-        this.isLoading = false;
-      }, 200);
-    });
+    const finish = () => {
+      clearTimeout(this.showTimer);
+      this.isLoading = false;
+    };
+    this.stopGuards = [
+      this.$router.beforeEach((to, from, next) => {
+        clearTimeout(this.showTimer);
+        this.showTimer = setTimeout(() => {
+          this.isLoading = true;
+        }, SLOW_NAVIGATION_MS);
+        next();
+      }),
+      this.$router.afterEach(finish),
+      this.$router.onError(finish),
+    ];
+  },
+  beforeUnmount() {
+    clearTimeout(this.showTimer);
+    (this.stopGuards || []).forEach((stop) => stop());
   },
 };
 </script>

--- a/src/components/imageGallery.vue
+++ b/src/components/imageGallery.vue
@@ -1,94 +1,236 @@
 <template>
     <div class="image-gallery">
-      <div v-for="(image, index) in images" :key="index" class="gallery-image" @click="openImage(index)">
-        <img :src="getThumbnail(image)" :alt="`Image ${index + 1}`" class="responsive-img" />
-      </div>
-      <div v-if="isViewerOpen" class="image-viewer" @click.self="closeViewer">
-        <img :src="getMediumResImage(images[currentImageIndex])" :alt="`Image ${currentImageIndex + 1}`" class="full-image" />
-        <div class="image-row">
-          <img v-for="(img, index) in images" :key="`thumb-${index}`" :src="getThumbnail(img)" @click.stop="navigateTo(index)" class="thumb" :class="{ active: currentImageIndex === index }">
-        </div>
-        <span class="close-btn" @click.stop="closeViewer">&times;</span>
-        <button class="download-btn" @click.stop="downloadImage(images[currentImageIndex])">Download full size.</button>
-      </div>
+      <button
+        v-for="(image, index) in images"
+        :key="image.original"
+        type="button"
+        class="gallery-item"
+        :style="itemStyle(image)"
+        :aria-label="`Open photo ${index + 1} of ${images.length}`"
+        @click="openImage(index)"
+      >
+        <img
+          ref="thumbs"
+          :src="image.thumb"
+          :alt="`${section} photo ${index + 1}`"
+          class="gallery-thumb"
+          :class="{ 'is-loaded': loaded[index] }"
+          :loading="index < EAGER_COUNT ? 'eager' : 'lazy'"
+          decoding="async"
+          @load="markLoaded(index)"
+          @error="markLoaded(index)"
+        >
+      </button>
+
+      <Teleport to="body">
+        <transition name="viewer" @after-leave="releaseScrollLock">
+          <div
+            v-if="isViewerOpen"
+            ref="viewer"
+            class="image-viewer"
+            role="dialog"
+            aria-modal="true"
+            :aria-label="`Photo ${currentImageIndex + 1} of ${images.length}`"
+            @click.self="closeViewer"
+          >
+            <header class="viewer-bar">
+              <span class="viewer-counter">{{ currentImageIndex + 1 }} / {{ images.length }}</span>
+              <span class="viewer-actions">
+                <a
+                  class="viewer-btn"
+                  :href="currentImage.original"
+                  download
+                  @click.stop
+                >full size ↓</a>
+                <button
+                  ref="closeBtn"
+                  class="viewer-btn"
+                  type="button"
+                  @click.stop="closeViewer"
+                >esc ×</button>
+              </span>
+            </header>
+
+            <div class="viewer-stage" @click.self="closeViewer">
+              <button
+                class="viewer-nav viewer-prev"
+                type="button"
+                aria-label="Previous photo"
+                @click.stop="navigate(-1)"
+              >‹</button>
+              <!-- The cached grid thumbnail shows as a background while the
+                   medium-res file decodes, so the stage never appears empty. -->
+              <img
+                :key="currentImage.medium"
+                :src="currentImage.medium"
+                :alt="`${section} photo ${currentImageIndex + 1}`"
+                class="viewer-image"
+                decoding="async"
+                :style="{
+                  '--ar': currentImage.w / currentImage.h,
+                  backgroundImage: `url('${currentImage.thumb}')`,
+                }"
+              >
+              <button
+                class="viewer-nav viewer-next"
+                type="button"
+                aria-label="Next photo"
+                @click.stop="navigate(1)"
+              >›</button>
+            </div>
+
+            <div class="viewer-strip">
+              <button
+                v-for="(image, index) in images"
+                :key="`strip-${image.original}`"
+                ref="stripThumbs"
+                type="button"
+                class="strip-item"
+                :class="{ active: currentImageIndex === index }"
+                :aria-label="`Photo ${index + 1}`"
+                @click.stop="navigateTo(index)"
+              >
+                <img :src="image.thumb" alt="" loading="lazy" decoding="async">
+              </button>
+            </div>
+          </div>
+        </transition>
+      </Teleport>
     </div>
   </template>
 
 <script>
+// Target row height for the justified layout; rows flex to fill the width.
+const ROW_BASIS_PX = 220;
+// Above-the-fold thumbnails load eagerly so the grid paints instantly;
+// the rest lazy-load as the page scrolls.
+const EAGER_COUNT = 8;
+
 export default {
     props: {
+        // [{ original, thumb, medium, w, h }] — built by photoSection.vue
+        // from the imageDictionary/imageMeta manifests.
         images: {
             type: Array,
             required: true,
         },
+        section: {
+            type: String,
+            default: 'gallery',
+        },
     },
     data() {
         return {
+            EAGER_COUNT,
             isViewerOpen: false,
             currentImageIndex: 0,
-            loadedImages: {}, // Track loaded images
+            loaded: {},
         };
+    },
+    computed: {
+        currentImage() {
+            return this.images[this.currentImageIndex] || {};
+        },
+    },
+    watch: {
+        // The scroll lock engages immediately on open but is released by
+        // @after-leave, so the page doesn't jump under the closing fade.
+        isViewerOpen(open) {
+            if (open) document.body.classList.add('viewer-open');
+        },
     },
     mounted() {
         window.addEventListener('keydown', this.handleKeydown);
+        // Images served from cache can fire `load` before the handler binds.
+        (this.$refs.thumbs || []).forEach((img, index) => {
+            if (img.complete && img.naturalWidth > 0) this.markLoaded(index);
+        });
     },
-    beforeDestroy() {
+    beforeUnmount() {
         window.removeEventListener('keydown', this.handleKeydown);
+        this.releaseScrollLock();
     },
     methods: {
-        getThumbnail(imageSrc) {
-            return this.loadedImages[imageSrc] || imageSrc.replace('/original/', '/thumbnails/');
+        // Justified rows: each tile grows proportionally to its aspect ratio,
+        // and `aspect-ratio` reserves space before the lazy thumbnail loads.
+        itemStyle(image) {
+            const ratio = image.w / image.h;
+            return {
+                aspectRatio: `${image.w} / ${image.h}`,
+                flexGrow: ratio * 100,
+                flexBasis: `${ratio * ROW_BASIS_PX}px`,
+            };
         },
-        getMediumResImage(imageSrc) {
-            return imageSrc.replace('/original/', '/medium_res/');
-        },
-        preloadImages() {
-            this.images.forEach(imageSrc => {
-                const img = new Image();
-                img.onload = () => {
-                    this.$set(this.loadedImages, imageSrc, imageSrc); // Track loaded original image
-                };
-                img.src = imageSrc; // Start loading the original image
-            });
+        markLoaded(index) {
+            if (this.loaded[index]) return;
+            this.loaded = { ...this.loaded, [index]: true };
         },
         openImage(index) {
-            this.isViewerOpen = true;
+            this.lastFocused = document.activeElement;
             this.currentImageIndex = index;
+            this.isViewerOpen = true;
+            this.afterIndexChange();
+            this.$nextTick(() => this.$refs.closeBtn?.focus());
         },
         closeViewer() {
             this.isViewerOpen = false;
+            this.$nextTick(() => this.lastFocused?.focus?.());
+        },
+        releaseScrollLock() {
+            document.body.classList.remove('viewer-open');
         },
         navigateTo(index) {
             this.currentImageIndex = index;
+            this.afterIndexChange();
+        },
+        navigate(direction) {
+            const count = this.images.length;
+            this.currentImageIndex = (this.currentImageIndex + direction + count) % count;
+            this.afterIndexChange();
+        },
+        afterIndexChange() {
+            this.preloadNeighbors();
+            this.scrollStripToActive();
+        },
+        preloadNeighbors() {
+            [-1, 1].forEach((offset) => {
+                const count = this.images.length;
+                const neighbor = this.images[(this.currentImageIndex + offset + count) % count];
+                if (neighbor) new Image().src = neighbor.medium;
+            });
+        },
+        scrollStripToActive() {
+            this.$nextTick(() => {
+                const el = (this.$refs.stripThumbs || [])[this.currentImageIndex];
+                if (el) el.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+            });
         },
         handleKeydown(e) {
             if (!this.isViewerOpen) return;
-            if (e.key === 'ArrowLeft') {
-                this.navigate(-1);
-            } else if (e.key === 'ArrowRight') {
-                this.navigate(1);
-            }
-            if (e.key === 'Escape') {
-                this.closeViewer();
-            }
+            if (e.key === 'ArrowLeft') this.navigate(-1);
+            else if (e.key === 'ArrowRight') this.navigate(1);
+            else if (e.key === 'Escape') this.closeViewer();
+            else if (e.key === 'Tab') this.trapFocus(e);
         },
-        navigate(direction) {
-            const nextIndex = this.currentImageIndex + direction;
-            if (nextIndex >= this.images.length) {
-                this.currentImageIndex = 0;
-            } else if (nextIndex < 0) {
-                this.currentImageIndex = this.images.length - 1;
-            } else {
-                this.currentImageIndex = nextIndex;
+        // aria-modal alone doesn't confine keyboard focus — keep Tab cycling
+        // within the dialog while it's open.
+        trapFocus(e) {
+            const viewer = this.$refs.viewer;
+            if (!viewer) return;
+            const focusables = viewer.querySelectorAll('button, a[href]');
+            if (!focusables.length) return;
+            const first = focusables[0];
+            const last = focusables[focusables.length - 1];
+            if (e.shiftKey && document.activeElement === first) {
+                e.preventDefault();
+                last.focus();
+            } else if (!e.shiftKey && document.activeElement === last) {
+                e.preventDefault();
+                first.focus();
+            } else if (!viewer.contains(document.activeElement)) {
+                e.preventDefault();
+                first.focus();
             }
-        },
-        downloadImage(imageSrc) {
-            const link = document.createElement('a');
-            link.href = imageSrc;
-            link.download = 'Download';
-            document.body.appendChild(link);
-            link.click();
-            document.body.removeChild(link);
         },
     },
 };
@@ -98,71 +240,185 @@ export default {
 .image-gallery {
     display: flex;
     flex-wrap: wrap;
-    gap: 10px;
-    justify-content: flex-start;
+    gap: 8px;
+    margin-top: 1.4em;
 }
 
-.gallery-image img.responsive-img {
-    max-height: 180px;
-    max-width: 100%;
-    height: auto;
-    width: auto;
-    cursor: pointer;
-    border-radius: 5px;
+/* Stop the last row from stretching to full width. */
+.image-gallery::after {
+    content: '';
+    flex-grow: 1000000;
 }
 
-.image-viewer {
-    position: fixed;
-    top: 0;
-    left: 0;
+.gallery-item {
+    position: relative;
+    padding: 0;
+    border: 0;
+    background: var(--bg_acc);
+    cursor: zoom-in;
+    overflow: hidden;
+}
+
+.gallery-thumb {
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.9);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
+    object-fit: cover;
+    display: block;
+    opacity: 0;
+    transition: opacity 0.35s ease, transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.full-image {
-    max-height: 80%;
-    max-width: 80%;
-}
-
-.image-row {
-    display: flex;
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    padding-top: 20px;
-}
-
-.thumb {
-    max-height: 100px;
-    margin-right: 10px;
-    opacity: 0.6;
-    transition: opacity 0.2s;
-}
-
-.thumb.active {
+.gallery-thumb.is-loaded {
     opacity: 1;
 }
 
-.close-btn {
-    position: absolute;
-    top: 20px;
-    right: 25px;
-    font-size: 40px;
-    color: white;
-    cursor: pointer;
+.gallery-item:hover .gallery-thumb {
+    transform: scale(1.025);
 }
 
-.download-btn {
-    margin-top: 20px;
-    padding: 10px 20px;
-    background-color: #fff;
-    border: none;
-    border-radius: 5px;
+/* ---------- lightbox ---------- */
+.image-viewer {
+    position: fixed;
+    inset: 0;
+    background: rgba(12, 12, 16, 0.94);
+    display: flex;
+    flex-direction: column;
+    z-index: 1000;
+    color: #fff;
+}
+
+.viewer-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 18px;
+    font: 12px/1.4 var(--font-mono);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.viewer-counter {
+    opacity: 0.75;
+}
+
+.viewer-actions {
+    display: flex;
+    gap: 10px;
+}
+
+.viewer-btn {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    color: #fff;
+    font: inherit;
+    padding: 3px 10px;
     cursor: pointer;
+    text-decoration: none;
+}
+
+.viewer-btn:hover {
+    background: #fff;
+    color: #111;
+}
+
+.viewer-stage {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    min-height: 0;
+    padding: 0 8px;
+}
+
+.viewer-image {
+    height: min(74vh, calc(86vw / var(--ar)));
+    aspect-ratio: var(--ar);
+    object-fit: contain;
+    background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+.viewer-nav {
+    background: transparent;
+    border: 0;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 44px;
+    line-height: 1;
+    padding: 0 14px;
+    cursor: pointer;
+    user-select: none;
+    flex-shrink: 0;
+}
+
+.viewer-nav:hover {
+    color: #fff;
+}
+
+.viewer-strip {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    padding: 12px 18px 16px;
+    scrollbar-width: thin;
+}
+
+.strip-item {
+    padding: 0;
+    border: 1px solid transparent;
+    background: transparent;
+    cursor: pointer;
+    flex-shrink: 0;
+    opacity: 0.45;
+    transition: opacity 0.15s ease, border-color 0.15s ease;
+}
+
+.strip-item img {
+    height: 56px;
+    width: auto;
+    display: block;
+}
+
+.strip-item:hover {
+    opacity: 0.85;
+}
+
+.strip-item.active {
+    opacity: 1;
+    border-color: #fff;
+}
+
+/* open/close fade */
+.viewer-enter-active,
+.viewer-leave-active {
+    transition: opacity 160ms ease;
+}
+
+.viewer-enter-from,
+.viewer-leave-to {
+    opacity: 0;
+}
+
+@media (max-width: 640px) {
+    .viewer-nav {
+        font-size: 32px;
+        padding: 0 8px;
+    }
+
+    .viewer-image {
+        height: auto;
+        max-width: 94vw;
+        max-height: 70vh;
+        width: min(94vw, calc(70vh * var(--ar)));
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .gallery-thumb,
+    .viewer-enter-active,
+    .viewer-leave-active {
+        transition: none !important;
+    }
 }
 </style>

--- a/src/components/photoGrid.vue
+++ b/src/components/photoGrid.vue
@@ -1,26 +1,50 @@
 <template>
-    <div class="category-grid">
-      <div class="category-card" v-for="category in categories" :key="category.name" @click="goToCategory(category.link)">
-        <img :src="category.image" :alt="category.name" class="category-image">
-        <div class="category-name">{{ category.name }}</div>
-      </div>
-    </div>
+    <nav class="category-grid" aria-label="Photo categories">
+      <router-link
+        v-for="category in categories"
+        :key="category.name"
+        :to="category.link"
+        class="category-card"
+        @pointerenter="warm(category)"
+        @focus="warm(category)"
+      >
+        <span class="category-frame">
+          <img
+            :src="category.image"
+            :alt="category.name + ' photos'"
+            class="category-image"
+            decoding="async"
+          >
+        </span>
+        <span class="category-name">
+          <span>{{ category.name }}</span>
+          <span class="category-arrow" aria-hidden="true">→</span>
+        </span>
+      </router-link>
+    </nav>
   </template>
 
 <script>
 import { photoCategories } from '/src/lib/siteContent.js';
+import { prefetchSectionThumbs } from '/src/lib/prefetch.js';
 
 export default {
     name: 'CategoryGrid',
     data() {
         return {
             categories: photoCategories,
+            warmed: {},
         };
     },
     methods: {
-        goToCategory(link) {
-            this.$router.push(link);
-        }
-    }
+        // Hovering a card warms that section's gallery thumbnails so the
+        // category page paints instantly on click.
+        warm(category) {
+            const section = category.link.split('/').pop();
+            if (this.warmed[section]) return;
+            this.warmed = { ...this.warmed, [section]: true };
+            prefetchSectionThumbs(section);
+        },
+    },
 };
 </script>

--- a/src/components/photoSection.vue
+++ b/src/components/photoSection.vue
@@ -1,13 +1,14 @@
 <template>
-    <div>
-      <ImageGallery :images="filteredImages"></ImageGallery>
-    </div>
+    <ImageGallery :images="images" :section="section_name" />
   </template>
 
 <script>
 import ImageGallery from '/src/components/imageGallery.vue';
-import imageDictionary from '/src/assets/imageDictionary.json'
+import imageDictionary from '/src/assets/imageDictionary.json';
+import imageMeta from '/src/assets/imageMeta.json';
 
+const toThumb = (src) => src.replace('/original/', '/thumbnails/');
+const toMedium = (src) => src.replace('/original/', '/medium_res/');
 
 export default {
     components: {
@@ -19,13 +20,22 @@ export default {
             required: true
         }
     },
-    data() {
-        return {
-            filteredImages: imageDictionary[this.section_name] || []
-        }
-    },
-    mounted() {
-        // If you need to do any transformations or additional fetching
+    computed: {
+        // Dimensions come from the build-time manifest so the gallery can
+        // reserve space (aspect-ratio) before lazy images arrive.
+        images() {
+            const list = imageDictionary[this.section_name] || [];
+            return list.map((src) => {
+                const meta = imageMeta[src] || { w: 3, h: 2 };
+                return {
+                    original: src,
+                    thumb: toThumb(src),
+                    medium: toMedium(src),
+                    w: meta.w,
+                    h: meta.h,
+                };
+            });
+        },
     },
 }
 </script>

--- a/src/lib/viewTransitions.js
+++ b/src/lib/viewTransitions.js
@@ -1,0 +1,66 @@
+// Route changes animate through the View Transitions API: the DOM swaps
+// instantly and the browser crossfades composited snapshots, so navigation
+// has zero dead time (unlike out-in component transitions, which wait for a
+// fade-out before mounting the next page). Browsers without the API simply
+// get an instant swap.
+//
+// The animation itself is defined in scss/_main.scss under
+// `::view-transition-*` — topnav, main and footer each get their own
+// snapshot so the chrome stays put while page content morphs.
+
+import { nextTick } from 'vue';
+import { START_LOCATION } from 'vue-router';
+import { terminalState } from './terminalMode.js';
+
+export function installViewTransitions(router) {
+  if (typeof document === 'undefined' || typeof document.startViewTransition !== 'function') {
+    return;
+  }
+
+  let finishTransition = null;
+
+  // Unfreeze rendering. Safe to call when no transition is pending.
+  const settle = () => {
+    if (finishTransition) {
+      finishTransition();
+      finishTransition = null;
+    }
+  };
+
+  router.beforeResolve((to, from) => {
+    if (from === START_LOCATION) return; // initial load — nothing to animate
+    if (to.fullPath === from.fullPath) return;
+    if (terminalState.active) return; // CLI handles its own rendering
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    settle(); // a rapid second navigation must release the previous snapshot
+
+    return new Promise((proceed) => {
+      let localDone = null;
+      const transition = document.startViewTransition(
+        () =>
+          new Promise((done) => {
+            localDone = done;
+            finishTransition = done;
+            proceed(); // let vue-router confirm the navigation and patch the DOM
+          })
+      );
+      // Safety net: if the browser abandons the transition (skipped,
+      // interrupted, snapshot failure), release the frozen callback so the
+      // page never hangs. Only settle globally if a newer navigation hasn't
+      // already taken over.
+      transition.ready.catch(() => {
+        if (!localDone) return;
+        if (finishTransition === localDone) settle();
+        else localDone();
+      });
+    });
+  });
+
+  // The DOM is patched on the tick after navigation confirms; only then may
+  // the browser snapshot the new state and start animating.
+  router.afterEach(() => {
+    nextTick(settle);
+  });
+  router.onError(settle);
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router';
+import { installViewTransitions } from '../lib/viewTransitions.js';
 import Home from '../views/home.vue';
 import Writing from '../views/writing.vue';
 import Keyboard from '../views/keyboards.vue';
@@ -51,11 +52,15 @@ const routes = [
 const router = createRouter({
 	history: createWebHistory(),
 	routes,
+	// Instant jumps: an animated scroll on every route change reads as lag.
+	// Smooth scrolling stays only for same-page anchor links.
 	scrollBehavior(to, from, savedPosition) {
 		if (savedPosition) return savedPosition;
 		if (to.hash) return { el: to.hash, behavior: 'smooth' };
-		return { top: 0, behavior: 'smooth' };
+		return { top: 0 };
 	},
 });
+
+installViewTransitions(router);
 
 export default router;

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -6,7 +6,9 @@
 
 html, body { margin: 0; padding: 0; }
 
-html { scroll-behavior: smooth; }
+/* No global smooth scrolling: it animates the router's scroll-to-top on
+   every navigation, which reads as lag. Anchor links opt in via the
+   router's scrollBehavior instead. */
 
 body {
     font-family: var(--font-sans);
@@ -19,6 +21,11 @@ body {
     margin: 8px auto;
     max-width: 95%;
     overflow-y: scroll;
+}
+
+/* Lock page scroll while the photo lightbox is open. */
+body.viewer-open {
+    overflow: hidden;
 }
 
 @media (min-width: 768px) {
@@ -224,7 +231,8 @@ article p {
 
 article p:last-child { margin-bottom: 0; }
 
-article strike {
+article strike,
+article s {
     color: var(--fg);
     opacity: 0.65;
     text-decoration-thickness: 2px;
@@ -380,22 +388,107 @@ footer.site-footer a:hover {
 }
 
 /* ============================================================
-   ROUTE TRANSITION (article + dirlist crossfade)
+   ROUTE TRANSITION — View Transitions API
+   The DOM swaps instantly; the browser crossfades snapshots on the
+   compositor. Chrome stays put: topnav, main and footer each get their
+   own snapshot so only page content visibly changes.
    ============================================================ */
-.fade-enter-active,
-.fade-leave-active {
-    transition: opacity 160ms ease;
+@supports (view-transition-name: none) {
+    .topnav { view-transition-name: topnav; }
+    main { view-transition-name: page-main; }
+    footer.site-footer { view-transition-name: site-footer; }
 }
 
-.fade-enter-from,
-.fade-leave-to { opacity: 0; }
+@supports (view-transition-name: none) {
+    /* Keep every layer's lifetime aligned: the overlay tears down when the
+       longest animation ends, so nothing may outlive the fades. */
+    ::view-transition-group(*) {
+        animation-duration: 160ms;
+        animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    }
 
-.fade-enter-to,
-.fade-leave-from { opacity: 1; }
+    /* The command bar must feel bolted to the page: crossfading its old/new
+       snapshots double-exposes the breadcrumb and back button (the content
+       that differs between routes) and reads as flicker. Swap it instantly —
+       new bar fully opaque from the first frame, no fade, no geometry tween. */
+    ::view-transition-group(topnav) {
+        animation: none;
+    }
+
+    ::view-transition-image-pair(topnav) {
+        animation: none;
+    }
+
+    ::view-transition-old(topnav) {
+        animation: none;
+        opacity: 0;
+    }
+
+    ::view-transition-new(topnav) {
+        animation: none;
+        opacity: 1;
+        mix-blend-mode: normal;
+    }
+
+    ::view-transition-old(root),
+    ::view-transition-new(root) {
+        animation-duration: 140ms;
+    }
+
+    /* No geometry morphs: animating the box's size/position detaches its
+       frame from the command bar (sliding side borders, a flashing seam),
+       especially when the old page was scrolled. Geometry snaps; only the
+       pixels crossfade. The bar and box frame are identical between pages,
+       and the browser's plus-lighter blend keeps identical pixels constant
+       through a matched crossfade — so the chrome holds perfectly still
+       while the content inside fades. */
+    ::view-transition-group(page-main),
+    ::view-transition-group(site-footer) {
+        animation: none;
+    }
+
+    ::view-transition-old(page-main),
+    ::view-transition-new(page-main),
+    ::view-transition-old(site-footer),
+    ::view-transition-new(site-footer) {
+        animation-duration: 160ms;
+        animation-timing-function: ease;
+        /* `animation: none` on the parent group resets the fill-mode these
+           images normally inherit — without `both`, the old snapshot pops
+           back to full opacity after its fade-out ends and the previous
+           page flashes for the overlay's remaining frames. */
+        animation-fill-mode: both;
+    }
+}
 
 @media (prefers-reduced-motion: reduce) {
-    .fade-enter-active,
-    .fade-leave-active { transition: none !important; }
+    ::view-transition-group(*),
+    ::view-transition-old(*),
+    ::view-transition-new(*) {
+        animation: none !important;
+    }
+}
+
+/* ============================================================
+   INTERACTION STATES — keyboard focus + press feedback
+   ============================================================ */
+:focus-visible {
+    outline: 2px solid var(--fg);
+    outline-offset: 2px;
+}
+
+.topnav :focus-visible {
+    outline-color: var(--bg);
+    outline-offset: 1px;
+}
+
+nav.articles-list .row:active {
+    transform: translateY(1px);
+}
+
+.back-btn:active,
+.theme-btn:active {
+    transform: translateY(1px);
 }
 
 /* ============================================================
@@ -403,5 +496,16 @@ footer.site-footer a:hover {
    ============================================================ */
 @media (max-width: 520px) {
     .topnav { font-size: 12px; padding: 6px 10px; }
+
+    /* Long slugs (writing posts) would wrap the breadcrumb into the
+       buttons — ellipsize each segment instead. */
+    .topnav .crumbs a,
+    .topnav .crumb-cli {
+        max-width: 14ch;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
     article { padding: 1.2em 18px; }
 }

--- a/src/scss/_photoSection.scss
+++ b/src/scss/_photoSection.scss
@@ -1,44 +1,73 @@
+/* ============================================================
+   PHOTO CATEGORY GRID (/photography)
+   Cards follow the site's box language: hard corners, 2px rules,
+   mono uppercase labels that invert on hover.
+   ============================================================ */
 .category-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1rem;
-    padding: 1rem;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 14px;
+    margin-top: 1.4em;
 }
 
 .category-card {
-    cursor: pointer;
-    background-color: var(--bg);
+    display: flex;
+    flex-direction: column;
     border: 2px solid var(--fg);
-    border-radius: 0.5rem;
+    background: var(--bg);
+    text-decoration: none;
+    color: var(--fg);
     overflow: hidden;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-    will-change: transform;
 }
 
 .category-card:hover {
-    transform: translateY(-5px);
+    background: var(--bg);
+    color: var(--fg);
+}
+
+.category-frame {
+    display: block;
+    aspect-ratio: 4 / 3;
+    overflow: hidden;
+    background: var(--bg_acc);
 }
 
 .category-image {
     width: 100%;
-    height: 200px;
+    height: 100%;
     object-fit: cover;
-    background-color: var(--bg_acc);
-    transition: opacity 0.3s ease;
+    display: block;
+    transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.category-image[loading] {
-    opacity: 0.5;
-}
-
-.category-image.loaded {
-    opacity: 1;
+.category-card:hover .category-image,
+.category-card:focus-visible .category-image {
+    transform: scale(1.04);
 }
 
 .category-name {
-    padding: 0.5rem;
-    text-align: center;
-    font-weight: bold;
-    color: var(--fg);
-    /* Your foreground variable */
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    padding: 7px 12px;
+    border-top: 2px solid var(--fg);
+    font: 600 12px/1.4 var(--font-mono);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    transition: background 0.12s, color 0.12s;
+}
+
+.category-card:hover .category-name,
+.category-card:focus-visible .category-name {
+    background: var(--fg);
+    color: var(--bg);
+}
+
+.category-arrow {
+    transition: transform 0.18s ease;
+}
+
+.category-card:hover .category-arrow {
+    transform: translateX(4px);
 }

--- a/src/views/home.vue
+++ b/src/views/home.vue
@@ -3,7 +3,7 @@
       <article>
         <h1>Hello there!</h1>
         <p>I'm <router-link to="/about" class="abold">{Jaime}</router-link> a
-          <strike>data scientist, engineer, geek</strike> who likes to build stuff at the computer. Apart from coding my interests include photography, snow sports and cycling.</p>
+          <s>data scientist, engineer, geek</s> who likes to build stuff at the computer. Apart from coding my interests include photography, snow sports and cycling.</p>
         <p>I'm currently building <a href="https://ecomid.com" target="_blank" rel="noopener" class="abold">eComID</a> as co-founder and head of AI.</p>
       </article>
       <listDisplay :listItems="pages" :numbered="true" />


### PR DESCRIPTION
## Summary

The click UI felt sluggish next to the CLI. Root causes were UX-layer, not framework: every navigation paid ~320ms of dead time (out-in fade), a loading bar flashed on every click with a 200ms minimum, scroll-to-top animated on every route change, and the lightbox loaded full-resolution JPEGs (the medium tier was re-encoded at q50 but never resized).

### Navigation
- **View Transitions API** replaces the Vue out-in fade: the DOM swaps instantly and the browser crossfades composited snapshots (160ms, matched fill modes). Falls back to an instant swap on unsupported browsers / reduced motion, and is skipped while the CLI is active.
- Chrome never moves: the top bar, content-box frame, and footer snap to final geometry on frame one — only page content crossfades. (Three Chrome glitches hunted down along the way: breadcrumb ghosting from the bar crossfade, side borders detaching from a 5px content rise + geometry morphs, and an end-of-transition flash from `animation: none` resetting the inherited fill-mode.)
- Loading bar appears only when navigation genuinely stalls >250ms.
- Instant scroll restore; smooth scrolling only for anchor links.

### Photography
- Pipeline rewritten: incremental (mtime skip), EXIF rotation baked, medium tier capped at 2048px q75 mozjpeg (~47MB total vs hundreds before), thumbs 800px q75, emits `imageMeta.json` dimensions manifest.
- Justified-rows gallery with reserved aspect ratios (zero layout shift), first 8 thumbs eager + rest lazy.
- Category cards are real router-links (middle-click works) in the site's box language, with hover-prefetch of that section's thumbnails.
- Lightbox: counter, prev/next, keyboard arrows/Escape, neighbor preload, cached-thumb placeholder while the big file decodes, body scroll lock, focus trap + focus restore.

### Fixes
- `beforeDestroy` (Vue 2 API) never fires in Vue 3 — the gallery leaked a window keydown listener per visit.
- Removed stray unregistered `<SpeedInsights />` tag; `<strike>` → `<s>`; mobile breadcrumbs ellipsize instead of colliding with nav buttons; `:focus-visible` states throughout.

## Test plan
- [x] Browser-verified (headless Chromium): home → writing → post → back, photography → category → lightbox
- [x] Lightbox: arrows, Escape, Tab trap, focus restore, scroll lock release after fade
- [x] CLI mode regression: whoami / ls / cd writing all intact; transitions skipped while terminal active
- [x] Dark theme, mobile 375px (photography grid, writing post, lightbox)
- [x] Mid-transition frame captures: bar/box seam stable, no end-of-transition flash
- [x] `npm run build` green (incremental image step ~1s warm); main bundle 53KB gzip
- [ ] Verify on production Vercel deploy after merge (thumbnails/medium regenerate in CI)