### PR TITLE
Mobile view redesign: stacked list notes, one-line topnav, tighter layout

### DIFF
--- a/src/scss/_listdisplay.scss
+++ b/src/scss/_listdisplay.scss
@@ -146,25 +146,64 @@ nav.articles-list li .link-content .icon {
     display: none;
 }
 
-@media (max-width: 520px) {
+/* Mobile + narrow tablets: stack the note under the title instead of
+   squeezing it against the right edge (it ellipsizes into nonsense
+   below ~768px). The two .l wrappers dissolve (display: contents) so
+   the row becomes a 3-column grid:
+     [ico]  [name ...................]  [arrow]
+            [meta ............] [date]            */
+@media (max-width: 767px) {
     nav.articles-list .row,
     nav.articles-list li .link-content {
-        padding: 12px 18px;
-        flex-wrap: wrap;
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        align-items: baseline;
+        gap: 4px 0;
+        padding: 13px clamp(22px, 7%, 42px);
+    }
+
+    nav.articles-list .row .l { display: contents; }
+
+    nav.articles-list .ico {
+        grid-row: 1;
+        grid-column: 1;
+        margin-right: 12px;
     }
 
     nav.articles-list .name,
-    nav.articles-list .text-title { font-size: 17px; }
+    nav.articles-list .text-title {
+        grid-row: 1;
+        grid-column: 2;
+        font-size: 17px;
+    }
 
-    nav.articles-list .row .l:last-child {
-        flex-basis: 100%;
-        justify-content: flex-start;
-        margin-top: 4px;
+    nav.articles-list .arrow {
+        grid-row: 1;
+        grid-column: 3;
+        justify-self: end;
+        margin-left: 14px;
     }
 
     nav.articles-list .meta,
     nav.articles-list .text-description {
+        grid-row: 2;
+        grid-column: 2;
         text-align: left;
-        max-width: 100%;
+        max-width: none;
+    }
+
+    nav.articles-list .date {
+        grid-row: 2;
+        grid-column: 3;
+        justify-self: end;
+        margin-left: 14px;
+    }
+}
+
+/* Phones: match the tighter article gutter set in _main.scss. */
+@media (max-width: 520px) {
+    nav.articles-list .row,
+    nav.articles-list li .link-content {
+        padding: 13px 18px;
     }
 }

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -199,6 +199,13 @@ main img {
 article {
     padding: 1.6em clamp(22px, 7%, 42px);
     min-height: 256px;
+    overflow-wrap: break-word;
+}
+
+/* The desktop min-height gives sparse pages presence, but on phones it
+   reads as dead space between the intro and the list below it. */
+@media (max-width: 767px) {
+    article { min-height: 0; }
 }
 
 article h1 {
@@ -307,6 +314,19 @@ article details {
 
 /* Topnav already provides "back" — hide the legacy in-content back arrow */
 .back-button-container { display: none; }
+
+/* Below the grid breakpoint the about portrait sits in normal flow —
+   cap it so it doesn't render full-width on phones. */
+@media (max-width: 599px) {
+    .about-article .about-image {
+        margin-top: 1.4em;
+
+        img {
+            max-width: min(62%, 240px);
+            border: 1px solid var(--fg);
+        }
+    }
+}
 
 /* About-page two-column grid (kept) */
 @media (min-width: 600px) {
@@ -495,10 +515,26 @@ nav.articles-list .row:active {
    RESPONSIVE
    ============================================================ */
 @media (max-width: 520px) {
-    .topnav { font-size: 12px; padding: 6px 10px; }
+    /* Reclaim horizontal room: the desktop 95%-width + 15px padding
+       leaves only ~340px of content on a 390px phone. */
+    body {
+        max-width: 100%;
+        padding: 8px 10px;
+    }
 
-    /* Long slugs (writing posts) would wrap the breadcrumb into the
-       buttons — ellipsize each segment instead. */
+    .topnav {
+        font-size: 12px;
+        padding: 6px 10px;
+        gap: 10px;
+    }
+
+    /* Keep the breadcrumb on a single line: ellipsize each segment
+       instead of wrapping into the buttons. */
+    .topnav .crumbs {
+        flex-wrap: nowrap;
+        overflow: hidden;
+    }
+
     .topnav .crumbs a,
     .topnav .crumb-cli {
         max-width: 14ch;
@@ -506,6 +542,17 @@ nav.articles-list .row:active {
         text-overflow: ellipsis;
         white-space: nowrap;
     }
+
+    .topnav .right { gap: 6px; }
+
+    .back-btn,
+    .theme-btn {
+        font-size: 10px;
+        padding: 3px 6px;
+        letter-spacing: 0.05em;
+    }
+
+    .theme-btn { min-width: 0; }
 
     article { padding: 1.2em 18px; }
 }


### PR DESCRIPTION
## Summary

Mobile view was cramped and the notes on the right of the list rows rendered badly. This PR reworks the small-screen layout (SCSS only, no markup changes).

### List rows (`_listdisplay.scss`)
- Below 768px each row becomes a 3-column grid: `[number] [title] [arrow]` on the first line, with the note (and date) tucked directly under the title in small mono.
- Fixes two broken states:
  - **≤520px**: note + arrow wrapped onto a sparse second line with a large gap.
  - **521–767px**: note was crushed against the right edge and ellipsized into nonsense ("th…", "op…").
- Row gutters align with the article text at every width.

### Layout & chrome (`_main.scss`)
- Breadcrumb stays on a single line (segments ellipsize instead of wrapping into the buttons); BACK/CLI/DARK buttons compacted on phones.
- Page box uses nearly the full screen width on phones (was losing ~50px to margins + padding).
- `article` min-height (256px) dropped below 768px — removes the dead space between page intros and lists.
- About portrait capped at min(62%, 240px) with the desktop border treatment (it rendered full-width on phones).
- Long URLs wrap inside articles (`overflow-wrap: break-word`) — fixes overflow on the keyboards page.

## Test plan
- [x] Screenshot-verified home, writing, projects, creative, about, photography at 320px and 390px (iPhone 14)
- [x] Verified 640px (narrow tablet) shows full notes instead of ellipses
- [x] Verified long-slug article page keeps the breadcrumb on one line
- [x] Verified dark theme renders cleanly with the new rows
- [x] Verified desktop (1440px) is unchanged — 960px box, side-by-side notes
- [x] `vite build` passes