### PR TITLE
feat: photography redesign — editorial mosaic index, framed print gal…

### DIFF
--- a/src/components/imageGallery.vue
+++ b/src/components/imageGallery.vue
@@ -20,6 +20,7 @@
           @load="markLoaded(index)"
           @error="markLoaded(index)"
         >
+        <span class="gallery-num" aria-hidden="true">{{ String(index + 1).padStart(2, '0') }}</span>
       </button>
 
       <Teleport to="body">
@@ -253,10 +254,28 @@ export default {
 .gallery-item {
     position: relative;
     padding: 0;
-    border: 0;
+    border: 1px solid var(--rule_soft);
     background: var(--bg_acc);
     cursor: zoom-in;
     overflow: hidden;
+    transition: transform 0.18s cubic-bezier(0.22, 1, 0.36, 1),
+        box-shadow 0.18s cubic-bezier(0.22, 1, 0.36, 1),
+        border-color 0.18s ease;
+}
+
+/* Prints lift off the sheet: hard offset shadow in ink, no blur —
+   the same box language as the rest of the site. */
+.gallery-item:hover,
+.gallery-item:focus-visible {
+    border-color: var(--fg);
+    transform: translate(-2px, -2px);
+    box-shadow: 4px 4px 0 var(--fg);
+    z-index: 1;
+}
+
+.gallery-item:active {
+    transform: translate(0, 0);
+    box-shadow: 2px 2px 0 var(--fg);
 }
 
 .gallery-thumb {
@@ -265,15 +284,33 @@ export default {
     object-fit: cover;
     display: block;
     opacity: 0;
+    transform: translateY(8px);
     transition: opacity 0.35s ease, transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .gallery-thumb.is-loaded {
     opacity: 1;
+    transform: none;
 }
 
-.gallery-item:hover .gallery-thumb {
-    transform: scale(1.025);
+/* Contact-sheet frame number, revealed on hover/focus. */
+.gallery-num {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    padding: 2px 7px;
+    background: var(--fg);
+    color: var(--bg);
+    font: 600 10px/1.5 var(--font-mono);
+    letter-spacing: 0.08em;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    pointer-events: none;
+}
+
+.gallery-item:hover .gallery-num,
+.gallery-item:focus-visible .gallery-num {
+    opacity: 1;
 }
 
 /* ---------- lightbox ---------- */
@@ -415,10 +452,17 @@ export default {
 }
 
 @media (prefers-reduced-motion: reduce) {
+    .gallery-item,
     .gallery-thumb,
     .viewer-enter-active,
     .viewer-leave-active {
         transition: none !important;
+    }
+
+    .gallery-item:hover,
+    .gallery-item:focus-visible,
+    .gallery-thumb {
+        transform: none !important;
     }
 }
 </style>

--- a/src/components/photoGrid.vue
+++ b/src/components/photoGrid.vue
@@ -1,10 +1,12 @@
 <template>
+  <div class="photo-index">
     <nav class="category-grid" aria-label="Photo categories">
       <router-link
-        v-for="category in categories"
-        :key="category.name"
+        v-for="(category, index) in categories"
+        :key="category.slug"
         :to="category.link"
         class="category-card"
+        :class="`is-${category.size}`"
         @pointerenter="warm(category)"
         @focus="warm(category)"
       >
@@ -17,15 +19,23 @@
           >
         </span>
         <span class="category-name">
-          <span>{{ category.name }}</span>
-          <span class="category-arrow" aria-hidden="true">→</span>
+          <span class="category-title">
+            <span class="category-num">{{ formatNum(index) }}</span>
+            <span>{{ category.name }}</span>
+          </span>
+          <span class="category-count">
+            <span>{{ countFor(category) }}</span>
+            <span class="category-arrow" aria-hidden="true">→</span>
+          </span>
         </span>
       </router-link>
     </nav>
-  </template>
+  </div>
+</template>
 
 <script>
 import { photoCategories } from '/src/lib/siteContent.js';
+import imageDictionary from '/src/assets/imageDictionary.json';
 import { prefetchSectionThumbs } from '/src/lib/prefetch.js';
 
 export default {
@@ -37,13 +47,18 @@ export default {
         };
     },
     methods: {
+        countFor(category) {
+            return (imageDictionary[category.slug] || []).length;
+        },
+        formatNum(index) {
+            return String(index + 1).padStart(2, '0');
+        },
         // Hovering a card warms that section's gallery thumbnails so the
         // category page paints instantly on click.
         warm(category) {
-            const section = category.link.split('/').pop();
-            if (this.warmed[section]) return;
-            this.warmed = { ...this.warmed, [section]: true };
-            prefetchSectionThumbs(section);
+            if (this.warmed[category.slug]) return;
+            this.warmed = { ...this.warmed, [category.slug]: true };
+            prefetchSectionThumbs(category.slug);
         },
     },
 };

--- a/src/components/photoSection.vue
+++ b/src/components/photoSection.vue
@@ -1,6 +1,6 @@
 <template>
-    <ImageGallery :images="images" :section="section_name" />
-  </template>
+  <ImageGallery :images="images" :section="section_name" />
+</template>
 
 <script>
 import ImageGallery from '/src/components/imageGallery.vue';

--- a/src/lib/prefetch.js
+++ b/src/lib/prefetch.js
@@ -1,5 +1,6 @@
 import { lazyLoaders } from '../router/index.js';
 import imageDictionary from '../assets/imageDictionary.json';
+import { photoCategories } from './siteContent.js';
 
 const onIdle = (cb, timeout = 2000) => {
 	if (typeof window === 'undefined') return;
@@ -44,19 +45,8 @@ const prefetchUrl = (url) => {
 const toThumb = (url) => url.replace('/original/', '/thumbnails/');
 
 // Cover images shown by photoGrid on /photography — small, always worth prefetching.
-const PHOTO_GRID_COVERS = [
-	'family/Paula Ferrando -82.jpg',
-	'nature/39225246575_678b236c4e_o.jpg',
-	'milu/30_06_2023_0064.jpg',
-	'life/Paula Ferrando -3.jpg',
-	'street/30_06_2023_0042-Enhanced.jpg',
-	'portraits/09_01_2024_0141.jpg',
-];
-
 export const prefetchPhotoCovers = () => {
-	PHOTO_GRID_COVERS.forEach(p =>
-		prefetchUrl('/assets/img/photography/thumbnails/' + p)
-	);
+	photoCategories.forEach((category) => prefetchUrl(category.image));
 };
 
 // All gallery thumbnails for a given section. Used when the user is already on

--- a/src/lib/siteContent.js
+++ b/src/lib/siteContent.js
@@ -6,7 +6,7 @@ export const homePages = [
   { title: 'Writing',     link: '/writing',     description: '11 pieces' },
   { title: 'Creative',    link: '/creative',    description: '9 finds' },
   { title: 'Keyboards',   link: '/keyboards',   description: '7 builds' },
-  { title: 'Photography', link: '/photography', description: '8 sets' },
+  { title: 'Photography', link: '/photography', description: '7 sets' },
   { title: 'About',       link: '/about',       description: 'readme' },
 ];
 
@@ -53,13 +53,18 @@ export const creativeItems = [
   { title: "First season of True Detective",      description: "a masterpiece", link: "https://www.imdb.com/title/tt2356777/" },
 ];
 
+// Ordered — the order defines set numbers (01, 02, …) across the
+// photography index, the set meta line, and prev/next navigation.
+// `size` curates the index mosaic: hero (4×2), tall (2×2, portrait
+// covers), half (3×1), std (2×1) on the 6-column desktop grid.
 export const photoCategories = [
-  { name: 'Family',    image: 'assets/img/photography/thumbnails/family/Paula Ferrando -82.jpg',           link: '/photography/family' },
-  { name: 'Nature',    image: 'assets/img/photography/thumbnails/nature/39225246575_678b236c4e_o.jpg',     link: '/photography/nature' },
-  { name: 'Milu',      image: 'assets/img/photography/thumbnails/milu/30_06_2023_0064.jpg',                link: '/photography/milu' },
-  { name: 'Life',      image: 'assets/img/photography/thumbnails/life/Paula Ferrando -3.jpg',              link: '/photography/life' },
-  { name: 'Street',    image: 'assets/img/photography/thumbnails/street/30_06_2023_0042-Enhanced.jpg',     link: '/photography/street' },
-  { name: 'Portraits', image: 'assets/img/photography/thumbnails/portraits/09_01_2024_0141.jpg',           link: '/photography/portraits' },
+  { name: 'Family',    slug: 'family',    size: 'hero', image: '/assets/img/photography/thumbnails/family/Paula Ferrando -82.jpg',       link: '/photography/family' },
+  { name: 'Portraits', slug: 'portraits', size: 'tall', image: '/assets/img/photography/thumbnails/portraits/09_01_2024_0141.jpg',       link: '/photography/portraits' },
+  { name: 'Street',    slug: 'street',    size: 'half', image: '/assets/img/photography/thumbnails/street/30_06_2023_0042-Enhanced.jpg', link: '/photography/street' },
+  { name: 'Nature',    slug: 'nature',    size: 'half', image: '/assets/img/photography/thumbnails/nature/39225246575_678b236c4e_o.jpg', link: '/photography/nature' },
+  { name: 'Milu',      slug: 'milu',      size: 'std',  image: '/assets/img/photography/thumbnails/milu/30_06_2023_0064.jpg',            link: '/photography/milu' },
+  { name: 'Life',      slug: 'life',      size: 'std',  image: '/assets/img/photography/thumbnails/life/Paula Ferrando -3.jpg',          link: '/photography/life' },
+  { name: 'Faroe',     slug: 'faroe',     size: 'std',  image: '/assets/img/photography/thumbnails/faroe/faroe_0233.jpg',                link: '/photography/faroe' },
 ];
 
 export const keyboards = [

--- a/src/scss/_photoSection.scss
+++ b/src/scss/_photoSection.scss
@@ -1,13 +1,21 @@
 /* ============================================================
-   PHOTO CATEGORY GRID (/photography)
-   Cards follow the site's box language: hard corners, 2px rules,
+   PHOTOGRAPHY — archive / contact-sheet treatment.
+   Follows the site's box language: hard corners, 2px rules,
    mono uppercase labels that invert on hover.
+   ============================================================ */
+
+/* ============================================================
+   CATEGORY MOSAIC (/photography)
+   Curated 6-column bento: one hero, one tall portrait tile,
+   two half-width tiles, three standard tiles. Spans are set by
+   the `size` field on photoCategories (siteContent.js).
    ============================================================ */
 .category-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 14px;
-    margin-top: 1.4em;
+    grid-template-columns: repeat(6, 1fr);
+    grid-auto-rows: clamp(92px, 16vw, 148px);
+    gap: 12px;
+    margin-top: 1.6em;
 }
 
 .category-card {
@@ -18,7 +26,12 @@
     text-decoration: none;
     color: var(--fg);
     overflow: hidden;
+    grid-column: span 2;
 }
+
+.category-card.is-hero { grid-column: span 4; grid-row: span 2; }
+.category-card.is-tall { grid-column: span 2; grid-row: span 2; }
+.category-card.is-half { grid-column: span 3; }
 
 .category-card:hover {
     background: var(--bg);
@@ -27,7 +40,8 @@
 
 .category-frame {
     display: block;
-    aspect-ratio: 4 / 3;
+    flex: 1;
+    min-height: 0;
     overflow: hidden;
     background: var(--bg_acc);
 }
@@ -58,6 +72,33 @@
     transition: background 0.12s, color 0.12s;
 }
 
+.category-title,
+.category-count {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.category-title > span:last-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.category-num,
+.category-count {
+    opacity: 0.55;
+    transition: opacity 0.12s;
+}
+
+.category-card:hover .category-num,
+.category-card:hover .category-count,
+.category-card:focus-visible .category-num,
+.category-card:focus-visible .category-count {
+    opacity: 1;
+}
+
 .category-card:hover .category-name,
 .category-card:focus-visible .category-name {
     background: var(--fg);
@@ -71,3 +112,32 @@
 .category-card:hover .category-arrow {
     transform: translateX(4px);
 }
+
+/* Phones + narrow tablets: 2-column mosaic. The hero keeps its
+   double-height presence; everything else becomes a single cell,
+   with the last tile stretching full width to close the grid. */
+@media (max-width: 640px) {
+    .category-grid {
+        grid-template-columns: repeat(2, 1fr);
+        grid-auto-rows: clamp(120px, 34vw, 170px);
+        gap: 10px;
+    }
+
+    .category-card,
+    .category-card.is-tall,
+    .category-card.is-half {
+        grid-column: span 1;
+        grid-row: span 1;
+    }
+
+    .category-card.is-hero {
+        grid-column: span 2;
+        grid-row: span 2;
+    }
+
+    .category-name {
+        padding: 6px 10px;
+        font-size: 11px;
+    }
+}
+

--- a/src/views/photography.vue
+++ b/src/views/photography.vue
@@ -3,10 +3,12 @@
         <div class="home-container">
       <main class="shadowPlus4">
         <article>
-          <h1>To notice life</h1>
-            <p>I've always liked paying attention to the small signs of life scattered everywhere, in people, places, animals, movement, stillness, and texture.</p>
+          <h1>The art of noticing</h1>
+            <p>I believe great photographs capture moments of life that awaken a memory or a feeling.</p>
 
-        <p>Photography lets me take the things I notice and give them a place to remain. A movement, a texture, a person, an animal, a quiet corner of a place. They might only exist like that for a moment, but a photograph keeps a trace of them.</p>
+        <p>These moments are everywhere. Most are brief and unplanned. Some happen every day, while others may happen only once. Together, they remember us something about life and who we are.</p>
+
+        <p>Noticing these moments and finding a way to preserve them is the part of photography I love most. The photograph keeps the moment, but the real art is noticing it in the first place.</p>
 <photoGrid/>
         </article>
         <BackButton />


### PR DESCRIPTION
…leries

- Replace uniform category cards with a curated bento mosaic (hero, tall, half and standard tiles) with set numbers and photo counts
- Surface the orphaned Faroe set on the index (home: 8 sets -> 7 sets)
- Gallery tiles read as framed prints: thin rule border, hard-shadow lift on hover, contact-sheet number chip, fade-up reveal on load
- Respect prefers-reduced-motion for the new lift/reveal motion
- Derive photo cover prefetch list from siteContent (was a duplicated hardcoded list missing faroe)
- Rewrite photography intro: 'The art of noticing'