### PR TITLE
refactor: move keyboards under creative/, no longer a main page

### DIFF
--- a/public/fs.json
+++ b/public/fs.json
@@ -13,7 +13,7 @@
     "ls"
   ],
   "startkeyboards": [
-    "cd keyboards",
+    "cd creative",
     "ls"
   ],
   "uname": "Linux jiwidi 5.15.0-jaime #1 SMP x86_64 GNU/Linux",
@@ -44,7 +44,6 @@
         "projects": "_ilink:/projects",
         "writing": "_ilink:/writing",
         "creative": "_ilink:/creative",
-        "keyboards": "_ilink:/keyboards",
         "photography": "_ilink:/photography",
         "contact.txt": "email: hi@imjai.me · github: jiwidi · ecomid.com",
         ".secret": "you found it. cat .secret/wise to see something old."

--- a/public/rTerm.js
+++ b/public/rTerm.js
@@ -65,10 +65,13 @@ window.rTerm = function (options) {
 			window.onfocus = function () { window.blurred = false; };
 
 			if (this.data.upstart !== "undefined") {
-				var path = (options.url || window.location.pathname || "").split("/").filter(Boolean)[0];
+				var segments = (options.url || window.location.pathname || "").split("/").filter(Boolean);
+				var path = segments[0];
+				var isKeyboards = path === "keyboards" ||
+					(path === "creative" && segments[1] === "keyboards");
 				if (path === "photography" && this.data.startphotos) {
 					this.callPhotos();
-				} else if (path === "keyboards" && this.data.startkeyboards) {
+				} else if (isKeyboards && this.data.startkeyboards) {
 					this.callKeyboard();
 				} else if (path === "writing" && this.data.startblog) {
 					this.callBlog();

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -79,10 +79,10 @@ export default {
       const p = this.terminalState.previewPath || '';
       // surface section as the chip label: writing/foo → 'md', creative/x → 'md',
       // photography/x → 'set', projects → 'repo', etc. Default 'doc'.
+      if (p.startsWith('/creative/keyboards')) return 'kb';
       if (p.startsWith('/writing/') || p.startsWith('/creative/')) return 'md';
       if (p.startsWith('/photography')) return 'set';
       if (p.startsWith('/projects')) return 'repo';
-      if (p.startsWith('/keyboards')) return 'kb';
       if (p.startsWith('/about')) return 'me';
       return 'doc';
     },

--- a/src/lib/buildTerminalFs.js
+++ b/src/lib/buildTerminalFs.js
@@ -46,17 +46,23 @@ function itemsToFolder(items, getName) {
 export function buildTerminalData() {
   const writingFolder = itemsToFolder(writings, (it) => slug(it.title));
   const projectFolder = itemsToFolder(projects, (it) => slug(it.title));
-  const creativeFolder = itemsToFolder(creativeItems, (it) => slug(it.title));
+  // Keyboards lives as a subfolder of creative — drop its list entry so the
+  // terminal shows a real keyboards/ directory instead of a duplicate link.
+  const creativeFolder = itemsToFolder(
+    creativeItems.filter((it) => it.link !== '/creative/keyboards'),
+    (it) => slug(it.title),
+  );
   const photoFolder = itemsToFolder(photoCategories, (it) => slug(it.name));
 
   // Keyboards: each entry becomes a "file" whose contents (cat) describe it,
-  // plus a top-level _ilink to the page itself.
+  // plus an _ilink to the page itself.
   const keyboardFolder = {
-    'README.md': '_ilink:/keyboards',
+    'README.md': '_ilink:/creative/keyboards',
   };
   for (const k of keyboards) {
     keyboardFolder[slug(k.name) + '.md'] = k.name + ' — ' + k.summary;
   }
+  creativeFolder['keyboards'] = keyboardFolder;
 
   // About: short text plus links.
   const aboutFolder = {
@@ -76,7 +82,6 @@ export function buildTerminalData() {
     'projects':    projectFolder,
     'writing':     writingFolder,
     'creative':    creativeFolder,
-    'keyboards':   keyboardFolder,
     'photography': photoFolder,
     'contact.txt': 'email: hi@imjai.me · github: <a class="link" href="https://github.com/jiwidi" target="_blank">jiwidi</a> · <a class="link" href="https://ecomid.com" target="_blank">ecomid.com</a>',
     '.secret':     'try: cat .secret/wise',
@@ -90,7 +95,7 @@ export function buildTerminalData() {
     ],
     startblog: ['cd writing', 'ls'],
     startphotos: ['cd photography', 'ls'],
-    startkeyboards: ['cd keyboards', 'ls'],
+    startkeyboards: ['cd creative/keyboards', 'ls'],
     uname: 'Linux jiwidi 5.15.0-jaime #1 SMP x86_64 GNU/Linux',
     whoami: [
       'jaime ferrando huertas',

--- a/src/lib/siteContent.js
+++ b/src/lib/siteContent.js
@@ -5,7 +5,6 @@ export const homePages = [
   { title: 'Projects',    link: '/projects',    description: '12 repos' },
   { title: 'Writing',     link: '/writing',     description: '11 pieces' },
   { title: 'Creative',    link: '/creative',    description: '9 finds' },
-  { title: 'Keyboards',   link: '/keyboards',   description: '7 builds' },
   { title: 'Photography', link: '/photography', description: '7 sets' },
   { title: 'About',       link: '/about',       description: 'readme' },
 ];
@@ -51,6 +50,7 @@ export const creativeItems = [
   { title: "Tastiness of Watermelon",             description: "internal",      link: "/creative/watermelon" },
   { title: "If— by Rudyard Kipling",              description: "poem",          link: "/creative/kipling_if" },
   { title: "First season of True Detective",      description: "a masterpiece", link: "https://www.imdb.com/title/tt2356777/" },
+  { title: "Many Keyboards!",                     description: "7 builds",      link: "/creative/keyboards" },
 ];
 
 // Ordered — the order defines set numbers (01, 02, …) across the

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,7 +2,6 @@ import { createRouter, createWebHistory } from 'vue-router';
 import { installViewTransitions } from '../lib/viewTransitions.js';
 import Home from '../views/home.vue';
 import Writing from '../views/writing.vue';
-import Keyboard from '../views/keyboards.vue';
 import Creative from '../views/creative.vue';
 import About from '../views/about.vue';
 import Photography from '../views/photography.vue';
@@ -23,6 +22,7 @@ export const lazyLoaders = {
 	'writing/recsys_2022': () => import('../views/writing/recsys22.vue'),
 	'creative/watermelon': () => import('../views/creative/watermelon.vue'),
 	'creative/kipling_if': () => import('../views/creative/kipling_if.vue'),
+	'creative/keyboards': () => import('../views/creative/keyboards.vue'),
 	'photography/faroe': () => import('../views/photo_categories/faroe.vue'),
 	'photography/family': () => import('../views/photo_categories/family.vue'),
 	'photography/life': () => import('../views/photo_categories/life.vue'),
@@ -37,7 +37,8 @@ const routes = [
 	{ path: '/index.html', redirect: '/' },
 	{ path: '/', component: Home },
 	{ path: '/writing', component: Writing },
-	{ path: '/keyboards', component: Keyboard },
+	// Keyboards moved under creative — keep old links working.
+	{ path: '/keyboards', redirect: '/creative/keyboards' },
 	{ path: '/creative', component: Creative },
 	{ path: '/about', component: About },
 	{ path: '/projects', component: Projects },

--- a/src/views/creative/keyboards.vue
+++ b/src/views/creative/keyboards.vue
@@ -104,7 +104,7 @@
 <script>
 import BackButton from '/src/components/BackButton.vue';
 export default {
-    name: 'Creative',
+    name: 'Keyboards',
     components: {
         BackButton
     },


### PR DESCRIPTION
## Summary
- Keyboards is no longer a top-level section — the page moved to `/creative/keyboards`, lazy-loaded alongside the other creative subpages (so it's also prefetched on idle via `lazyLoaders`)
- `/keyboards` redirects to `/creative/keyboards` so existing links keep working
- Home directory list drops the Keyboards entry; the creative list gains "Many Keyboards! · 7 builds"
- Terminal (CLI) mode: the fake fs nests `keyboards/` inside `creative/`, the README `_ilink` points at the new path, the `kb` preview chip matches `/creative/keyboards`, and the URL auto-start (`cd creative/keyboards` + `ls`) follows the new route
- Legacy `public/fs.json` fallback updated for consistency; fixed a copy-pasted `name: 'Creative'` in the moved view

## Test plan
- [x] `npm run build` passes; keyboards ships as its own lazy chunk
- [x] Home page shows 5 sections, renumbered, no Keyboards
- [x] `/creative` lists the new keyboards entry linking to `/creative/keyboards`
- [x] `/creative/keyboards` renders full content + images, breadcrumb `//jaime / creative / keyboards`, BACK returns to `/creative`
- [x] Old `/keyboards` URL redirects to `/creative/keyboards`
- [x] CLI mode on `/creative/keyboards` auto-runs `cd creative/keyboards` + `ls` and lists all 7 builds
- [x] No console errors on any of the above